### PR TITLE
Auto Hammer bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed fluid usage modifiers not working for different tiers of sluice
 * Sluice items now all have tooltips showing their speed/fluid/etc. modifiers and abilities
 * Auto Hammers now correctly update their input/output locations when they're rotated by a wrench
+* Auto Hammers client animation playing when machine is not active
+* Auto Hammers not creating output buffer when no storage next to output
 
 ## [21.1.4]
 

--- a/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/hammer/AutoHammerBlockEntity.java
+++ b/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/hammer/AutoHammerBlockEntity.java
@@ -201,6 +201,10 @@ public class AutoHammerBlockEntity extends BlockEntity {
                     overflow.addLast(excess);
                 }
             }
+        } else {
+            for (ItemStack output : outputs) {
+                overflow.addLast(output.copy());
+            }
         }
         return overflow.isEmpty();
     }

--- a/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/hammer/AutoHammerBlockEntity.java
+++ b/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/hammer/AutoHammerBlockEntity.java
@@ -72,7 +72,7 @@ public class AutoHammerBlockEntity extends BlockEntity {
     }
 
     public void tickClient() {
-        if (!processingStack.isEmpty() && level != null) {
+        if (!processingStack.isEmpty() && level != null && getBlockState().getValue(AbstractMachineBlock.ACTIVE)) {
             if (++displayProgress >= props.getHammerSpeed()) {
                 displayProgress = 0;
                 if (processingStack.getItem() instanceof BlockItem blockItem) {


### PR DESCRIPTION
- Fixes output cache with no inventory https://github.com/FTBTeam/FTB-Modpack-Issues/issues/6818
- Fixes client animation playing when machine is not active 