### PR TITLE
allow machine GUIs on Sable sub-levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [21.1.19]
-
-### Fixed
-* Machine GUIs (Water Strainer, Fusing Machine, Super Cooler, Tempered Jar) can now be opened when the block is placed on a Create: Aeronautics / Sable airship sub-level
-  * Added an optional soft dependency on Sable: the block entity is resolved through its sub-level instead of the parent world
-
 ## [21.1.18]
 * Wooden Bowls (vanilla) can now be filled from water-containing tanks, taking 250mB water
 * The Dripper can now pull fluid from a tank above itself

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [21.1.19]
+
+### Fixed
+* Machine GUIs (Water Strainer, Fusing Machine, Super Cooler, Tempered Jar) can now be opened when the block is placed on a Create: Aeronautics / Sable airship sub-level
+  * Added an optional soft dependency on Sable: the block entity is resolved through its sub-level instead of the parent world
+
 ## [21.1.18]
 * Wooden Bowls (vanilla) can now be filled from water-containing tanks, taking 250mB water
 * The Dripper can now pull fluid from a tank above itself

--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,9 @@ dependencies {
 
     implementation("curse.maven:jade-324717:${jade_curse_id}")
 
+    compileOnly("curse.maven:sable-1312371:${sable_curse_id}")
+    compileOnly("dev.ryanhcode.sable-companion:sable-companion-common-${minecraft_version}:${sable_companion_version}")
+
     compileOnly("dev.latvian.mods:kubejs-neoforge:${kubejs_version}")
     compileOnly("dev.latvian.mods:rhino:${rhino_version}")
 }
@@ -103,6 +106,12 @@ repositories {
         }
     }
     maven { url "https://maven.latvian.dev/releases" }
+    maven {
+        url "https://maven.ryanhcode.dev/releases"
+        content {
+            includeGroup "dev.ryanhcode.sable-companion"
+        }
+    }
     maven {
         url "https://www.cursemaven.com"
         content {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ mod_id=ftbstuff
 # The human-readable display name for the mod.
 mod_name=FTB Stuff & Things
 mod_license=All Rights Reserved
-mod_version=21.1.19
+mod_version=21.1.18
 archives_base_name=ftb-stuff-things
 
 mod_group_id=dev.ftb.mods

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ mod_id=ftbstuff
 # The human-readable display name for the mod.
 mod_name=FTB Stuff & Things
 mod_license=All Rights Reserved
-mod_version=21.1.18
+mod_version=21.1.19
 archives_base_name=ftb-stuff-things
 
 mod_group_id=dev.ftb.mods
@@ -33,3 +33,6 @@ kubejs_version=2101.7.2-build.295
 rhino_version=2101.2.7-build.77
 # 15.4.1
 jade_curse_id=5729884
+# sable-neoforge-1.21.1-2.0.1
+sable_curse_id=8242682
+sable_companion_version=1.6.0

--- a/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/AbstractMachineBlock.java
+++ b/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/AbstractMachineBlock.java
@@ -2,6 +2,7 @@ package dev.ftb.mods.ftbstuffnthings.blocks;
 
 import dev.ftb.mods.ftbstuffnthings.client.ClientUtil;
 import dev.ftb.mods.ftbstuffnthings.registry.ComponentsRegistry;
+import dev.ftb.mods.ftbstuffnthings.util.SubLevelMenuHelper;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -132,7 +133,7 @@ public abstract class AbstractMachineBlock extends Block implements EntityBlock 
                 }
             }
             if (blockEntity instanceof MenuProvider menuProvider) {
-                player.openMenu(menuProvider, pos);
+                player.openMenu(menuProvider, buf -> SubLevelMenuHelper.writeLocator(buf, blockEntity));
             }
         }
         return ItemInteractionResult.sidedSuccess(level.isClientSide);

--- a/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/AbstractMachineMenu.java
+++ b/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/AbstractMachineMenu.java
@@ -39,7 +39,11 @@ public abstract class AbstractMachineMenu<T extends AbstractMachineBlockEntity> 
     protected ContainerData containerData;
 
     public AbstractMachineMenu(MenuType type, int windowId, Inventory invPlayer, FriendlyByteBuf extraData) {
-        this(type, windowId, invPlayer, SubLevelMenuHelper.readAndResolve(invPlayer.player, extraData));
+        this(type, windowId, invPlayer, getTile(invPlayer.player, extraData));
+    }
+
+    public static BlockEntity getTile(Player player, FriendlyByteBuf buf) {
+        return SubLevelMenuHelper.readAndResolve(player, buf);
     }
 
     public AbstractMachineMenu(MenuType type, int windowId, Inventory invPlayer) {

--- a/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/AbstractMachineMenu.java
+++ b/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/AbstractMachineMenu.java
@@ -17,6 +17,7 @@
 
 package dev.ftb.mods.ftbstuffnthings.blocks;
 
+import dev.ftb.mods.ftbstuffnthings.util.SubLevelMenuHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
@@ -30,6 +31,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.Vec3;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public abstract class AbstractMachineMenu<T extends AbstractMachineBlockEntity> extends AbstractContainerMenu {
     public final T blockEntity;
@@ -37,31 +39,22 @@ public abstract class AbstractMachineMenu<T extends AbstractMachineBlockEntity> 
     protected ContainerData containerData;
 
     public AbstractMachineMenu(MenuType type, int windowId, Inventory invPlayer, FriendlyByteBuf extraData) {
-        this(type, windowId, invPlayer, getTilePos(extraData));
+        this(type, windowId, invPlayer, SubLevelMenuHelper.readAndResolve(invPlayer.player, extraData));
     }
 
     public AbstractMachineMenu(MenuType type, int windowId, Inventory invPlayer) {
-        this(type, windowId, invPlayer, (BlockPos) null);
+        this(type, windowId, invPlayer, (BlockEntity) null);
     }
 
-    public AbstractMachineMenu(MenuType type, int windowId, Inventory invPlayer, BlockPos blockPos) {
+    public AbstractMachineMenu(MenuType type, int windowId, Inventory invPlayer, @Nullable BlockEntity blockEntity) {
         super(type, windowId);
-        if (blockPos != null) {
-            BlockEntity te0 = invPlayer.player.level().getBlockEntity(blockPos);
-            if (te0 instanceof AbstractMachineBlockEntity) {
-                //noinspection unchecked
-                blockEntity = (T) te0;  // safe cast: T extends AbstractMachineBlockEntity, and we're doing an instanceof
-                containerData = blockEntity.getContainerData();
-            } else {
-                blockEntity = null;
-            }
+        if (blockEntity instanceof AbstractMachineBlockEntity) {
+            //noinspection unchecked
+            this.blockEntity = (T) blockEntity;
+            containerData = this.blockEntity.getContainerData();
         } else {
-            blockEntity = null;
+            this.blockEntity = null;
         }
-    }
-
-    public static BlockPos getTilePos(FriendlyByteBuf buf) {
-        return buf.readBlockPos();
     }
 
     @Override

--- a/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/fusingmachine/FusingMachineBlockEntity.java
+++ b/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/fusingmachine/FusingMachineBlockEntity.java
@@ -203,7 +203,7 @@ public class FusingMachineBlockEntity extends AbstractMachineBlockEntity impleme
         if (player instanceof ServerPlayer sp) {
             fluidHandler.needSync(sp);
         }
-        return new FusingMachineMenu(windowId, inventory, getBlockPos());
+        return new FusingMachineMenu(windowId, inventory, this);
     }
 
     @Override

--- a/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/fusingmachine/FusingMachineMenu.java
+++ b/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/fusingmachine/FusingMachineMenu.java
@@ -2,7 +2,6 @@ package dev.ftb.mods.ftbstuffnthings.blocks.fusingmachine;
 
 import dev.ftb.mods.ftbstuffnthings.blocks.AbstractMachineMenu;
 import dev.ftb.mods.ftbstuffnthings.registry.ContentRegistry;
-import dev.ftb.mods.ftbstuffnthings.util.SubLevelMenuHelper;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -13,7 +12,7 @@ import java.util.Objects;
 
 public class FusingMachineMenu extends AbstractMachineMenu<FusingMachineBlockEntity> {
     public FusingMachineMenu(int windowId, Inventory playerInventory, FriendlyByteBuf buffer) {
-        this(windowId, playerInventory, SubLevelMenuHelper.readAndResolve(playerInventory.player, buffer));
+        this(windowId, playerInventory, getTile(playerInventory.player, buffer));
     }
 
     public FusingMachineMenu(int windowId, Inventory playerInventory, BlockEntity be) {

--- a/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/fusingmachine/FusingMachineMenu.java
+++ b/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/fusingmachine/FusingMachineMenu.java
@@ -2,9 +2,10 @@ package dev.ftb.mods.ftbstuffnthings.blocks.fusingmachine;
 
 import dev.ftb.mods.ftbstuffnthings.blocks.AbstractMachineMenu;
 import dev.ftb.mods.ftbstuffnthings.registry.ContentRegistry;
-import net.minecraft.core.BlockPos;
+import dev.ftb.mods.ftbstuffnthings.util.SubLevelMenuHelper;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.neoforged.neoforge.items.IItemHandler;
 import net.neoforged.neoforge.items.SlotItemHandler;
 
@@ -12,11 +13,11 @@ import java.util.Objects;
 
 public class FusingMachineMenu extends AbstractMachineMenu<FusingMachineBlockEntity> {
     public FusingMachineMenu(int windowId, Inventory playerInventory, FriendlyByteBuf buffer) {
-        this(windowId, playerInventory, getTilePos(buffer));
+        this(windowId, playerInventory, SubLevelMenuHelper.readAndResolve(playerInventory.player, buffer));
     }
 
-    public FusingMachineMenu(int windowId, Inventory playerInventory, BlockPos pos) {
-        super(ContentRegistry.FUSING_MACHINE_MENU.get(), windowId, playerInventory, pos);
+    public FusingMachineMenu(int windowId, Inventory playerInventory, BlockEntity be) {
+        super(ContentRegistry.FUSING_MACHINE_MENU.get(), windowId, playerInventory, be);
 
         IItemHandler itemHandler = Objects.requireNonNull(blockEntity.getItemHandler());
         addSlot(new SlotItemHandler(itemHandler, 0, 43, 27));

--- a/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/jar/TemperedJarBlock.java
+++ b/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/jar/TemperedJarBlock.java
@@ -5,6 +5,7 @@ import dev.ftb.mods.ftbstuffnthings.registry.ItemsRegistry;
 import dev.ftb.mods.ftbstuffnthings.temperature.Temperature;
 import dev.ftb.mods.ftbstuffnthings.temperature.TemperatureAndEfficiency;
 import dev.ftb.mods.ftbstuffnthings.util.MiscUtil;
+import dev.ftb.mods.ftbstuffnthings.util.SubLevelMenuHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.component.DataComponentType;
@@ -101,7 +102,7 @@ public class TemperedJarBlock extends JarBlock {
             if (!player.isShiftKeyDown()) {
                 if (!jar.onRightClick(player, hand)) {
                     player.openMenu(jar, buf -> {
-                        buf.writeBlockPos(pos);
+                        SubLevelMenuHelper.writeLocator(buf, jar);
                         buf.writeOptional(jar.getCurrentRecipeId(), FriendlyByteBuf::writeResourceLocation);
                     });
                 }

--- a/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/jar/TemperedJarBlockEntity.java
+++ b/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/jar/TemperedJarBlockEntity.java
@@ -147,7 +147,7 @@ public class TemperedJarBlockEntity extends BlockEntity implements MenuProvider 
     @Nullable
     @Override
     public AbstractContainerMenu createMenu(int containerId, Inventory playerInventory, Player player) {
-        return new TemperedJarMenu(containerId, playerInventory, getBlockPos());
+        return new TemperedJarMenu(containerId, playerInventory, this);
     }
 
     @Override

--- a/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/jar/TemperedJarMenu.java
+++ b/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/jar/TemperedJarMenu.java
@@ -1,8 +1,7 @@
 package dev.ftb.mods.ftbstuffnthings.blocks.jar;
 
-import dev.ftb.mods.ftbstuffnthings.registry.BlockEntitiesRegistry;
 import dev.ftb.mods.ftbstuffnthings.registry.ContentRegistry;
-import net.minecraft.core.BlockPos;
+import dev.ftb.mods.ftbstuffnthings.util.SubLevelMenuHelper;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
@@ -10,6 +9,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.items.SlotItemHandler;
 
@@ -20,17 +20,20 @@ public class TemperedJarMenu extends AbstractContainerMenu {
     private final TemperedJarBlockEntity jar;
 
     public static TemperedJarMenu fromNetwork(int containerId, Inventory invPlayer, FriendlyByteBuf extraData) {
-        TemperedJarMenu menu = new TemperedJarMenu(containerId, invPlayer, extraData.readBlockPos());
+        BlockEntity be = SubLevelMenuHelper.readAndResolve(invPlayer.player, extraData);
         ResourceLocation recipeId = extraData.readOptional(FriendlyByteBuf::readResourceLocation).orElse(null);
+        TemperedJarMenu menu = new TemperedJarMenu(containerId, invPlayer, be);
         menu.getJar().setCurrentRecipeId(recipeId);
         return menu;
     }
 
-    public TemperedJarMenu(int containerId, Inventory invPlayer, BlockPos blockPos) {
+    public TemperedJarMenu(int containerId, Inventory invPlayer, BlockEntity be) {
         super(ContentRegistry.TEMPERED_JAR_MENU.get(), containerId);
 
-        jar = invPlayer.player.level().getBlockEntity(blockPos, BlockEntitiesRegistry.TEMPERED_JAR.get())
-                .orElseThrow(() -> new IllegalStateException("tempered jar missing at " + blockPos));
+        if (!(be instanceof TemperedJarBlockEntity jarBlockEntity)) {
+            throw new IllegalStateException("tempered jar missing");
+        }
+        jar = jarBlockEntity;
 
         // player's main inventory
         for (int y = 0; y < 3; y++) {

--- a/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/jar/TemperedJarMenu.java
+++ b/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/jar/TemperedJarMenu.java
@@ -1,7 +1,7 @@
 package dev.ftb.mods.ftbstuffnthings.blocks.jar;
 
+import dev.ftb.mods.ftbstuffnthings.blocks.AbstractMachineMenu;
 import dev.ftb.mods.ftbstuffnthings.registry.ContentRegistry;
-import dev.ftb.mods.ftbstuffnthings.util.SubLevelMenuHelper;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
@@ -20,7 +20,7 @@ public class TemperedJarMenu extends AbstractContainerMenu {
     private final TemperedJarBlockEntity jar;
 
     public static TemperedJarMenu fromNetwork(int containerId, Inventory invPlayer, FriendlyByteBuf extraData) {
-        BlockEntity be = SubLevelMenuHelper.readAndResolve(invPlayer.player, extraData);
+        BlockEntity be = AbstractMachineMenu.getTile(invPlayer.player, extraData);
         ResourceLocation recipeId = extraData.readOptional(FriendlyByteBuf::readResourceLocation).orElse(null);
         TemperedJarMenu menu = new TemperedJarMenu(containerId, invPlayer, be);
         menu.getJar().setCurrentRecipeId(recipeId);

--- a/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/strainer/WaterStrainerBlockEntity.java
+++ b/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/strainer/WaterStrainerBlockEntity.java
@@ -81,7 +81,7 @@ public class WaterStrainerBlockEntity extends AbstractMachineBlockEntity {
 
     @Override
     public AbstractContainerMenu createMenu(int containerId, Inventory playerInventory, Player player) {
-        return new WaterStrainerMenu(containerId, playerInventory, getBlockPos());
+        return new WaterStrainerMenu(containerId, playerInventory, this);
     }
 
     @Override

--- a/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/strainer/WaterStrainerMenu.java
+++ b/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/strainer/WaterStrainerMenu.java
@@ -2,7 +2,6 @@ package dev.ftb.mods.ftbstuffnthings.blocks.strainer;
 
 import dev.ftb.mods.ftbstuffnthings.blocks.AbstractMachineMenu;
 import dev.ftb.mods.ftbstuffnthings.registry.ContentRegistry;
-import dev.ftb.mods.ftbstuffnthings.util.SubLevelMenuHelper;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.ItemStack;
@@ -15,7 +14,7 @@ import java.util.Objects;
 
 public class WaterStrainerMenu extends AbstractMachineMenu<WaterStrainerBlockEntity> {
     public WaterStrainerMenu(int windowId, Inventory playerInventory, FriendlyByteBuf buffer) {
-        this(windowId, playerInventory, SubLevelMenuHelper.readAndResolve(playerInventory.player, buffer));
+        this(windowId, playerInventory, getTile(playerInventory.player, buffer));
     }
 
     public WaterStrainerMenu(int containerId, Inventory playerInv, BlockEntity be) {

--- a/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/strainer/WaterStrainerMenu.java
+++ b/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/strainer/WaterStrainerMenu.java
@@ -2,10 +2,11 @@ package dev.ftb.mods.ftbstuffnthings.blocks.strainer;
 
 import dev.ftb.mods.ftbstuffnthings.blocks.AbstractMachineMenu;
 import dev.ftb.mods.ftbstuffnthings.registry.ContentRegistry;
-import net.minecraft.core.BlockPos;
+import dev.ftb.mods.ftbstuffnthings.util.SubLevelMenuHelper;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.neoforged.neoforge.items.IItemHandler;
 import net.neoforged.neoforge.items.SlotItemHandler;
 
@@ -14,11 +15,11 @@ import java.util.Objects;
 
 public class WaterStrainerMenu extends AbstractMachineMenu<WaterStrainerBlockEntity> {
     public WaterStrainerMenu(int windowId, Inventory playerInventory, FriendlyByteBuf buffer) {
-        this(windowId, playerInventory, AbstractMachineMenu.getTilePos(buffer));
+        this(windowId, playerInventory, SubLevelMenuHelper.readAndResolve(playerInventory.player, buffer));
     }
 
-    public WaterStrainerMenu(int containerId, Inventory playerInv, BlockPos pos) {
-        super(ContentRegistry.WATER_STRAINER_MENU.get(), containerId, playerInv, pos);
+    public WaterStrainerMenu(int containerId, Inventory playerInv, BlockEntity be) {
+        super(ContentRegistry.WATER_STRAINER_MENU.get(), containerId, playerInv, be);
 
         IItemHandler itemHandler = Objects.requireNonNull(blockEntity.getItemHandler());
 

--- a/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/supercooler/SuperCoolerBlockEntity.java
+++ b/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/supercooler/SuperCoolerBlockEntity.java
@@ -279,7 +279,7 @@ public class SuperCoolerBlockEntity extends AbstractMachineBlockEntity implement
         if (player instanceof ServerPlayer sp) {
             fluidHandler.needSync(sp);
         }
-        return new SuperCoolerMenu(containerId, inventory, getBlockPos());
+        return new SuperCoolerMenu(containerId, inventory, this);
     }
 
     @Override

--- a/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/supercooler/SuperCoolerMenu.java
+++ b/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/supercooler/SuperCoolerMenu.java
@@ -3,21 +3,22 @@ package dev.ftb.mods.ftbstuffnthings.blocks.supercooler;
 import dev.ftb.mods.ftbstuffnthings.blocks.AbstractMachineMenu;
 import dev.ftb.mods.ftbstuffnthings.capabilities.IOStackHandler;
 import dev.ftb.mods.ftbstuffnthings.registry.ContentRegistry;
-import net.minecraft.core.BlockPos;
+import dev.ftb.mods.ftbstuffnthings.util.SubLevelMenuHelper;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.neoforged.neoforge.items.IItemHandler;
 import net.neoforged.neoforge.items.SlotItemHandler;
 import org.jetbrains.annotations.NotNull;
 
 public class SuperCoolerMenu extends AbstractMachineMenu<SuperCoolerBlockEntity> {
     public SuperCoolerMenu(int windowId, Inventory playerInventory, FriendlyByteBuf buffer) {
-        this(windowId, playerInventory, getTilePos(buffer));
+        this(windowId, playerInventory, SubLevelMenuHelper.readAndResolve(playerInventory.player, buffer));
     }
 
-    public SuperCoolerMenu(int windowId, Inventory playerInventory, BlockPos pos) {
-        super(ContentRegistry.SUPER_COOLER_MENU.get(), windowId, playerInventory, pos);
+    public SuperCoolerMenu(int windowId, Inventory playerInventory, BlockEntity be) {
+        super(ContentRegistry.SUPER_COOLER_MENU.get(), windowId, playerInventory, be);
 
         int startY = 10;
         if (blockEntity.getItemHandler() instanceof IOStackHandler handler) {

--- a/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/supercooler/SuperCoolerMenu.java
+++ b/src/main/java/dev/ftb/mods/ftbstuffnthings/blocks/supercooler/SuperCoolerMenu.java
@@ -3,7 +3,6 @@ package dev.ftb.mods.ftbstuffnthings.blocks.supercooler;
 import dev.ftb.mods.ftbstuffnthings.blocks.AbstractMachineMenu;
 import dev.ftb.mods.ftbstuffnthings.capabilities.IOStackHandler;
 import dev.ftb.mods.ftbstuffnthings.registry.ContentRegistry;
-import dev.ftb.mods.ftbstuffnthings.util.SubLevelMenuHelper;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.ItemStack;
@@ -14,7 +13,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class SuperCoolerMenu extends AbstractMachineMenu<SuperCoolerBlockEntity> {
     public SuperCoolerMenu(int windowId, Inventory playerInventory, FriendlyByteBuf buffer) {
-        this(windowId, playerInventory, SubLevelMenuHelper.readAndResolve(playerInventory.player, buffer));
+        this(windowId, playerInventory, getTile(playerInventory.player, buffer));
     }
 
     public SuperCoolerMenu(int windowId, Inventory playerInventory, BlockEntity be) {

--- a/src/main/java/dev/ftb/mods/ftbstuffnthings/integration/sable/SableMenuCompat.java
+++ b/src/main/java/dev/ftb/mods/ftbstuffnthings/integration/sable/SableMenuCompat.java
@@ -1,0 +1,35 @@
+package dev.ftb.mods.ftbstuffnthings.integration.sable;
+
+import dev.ryanhcode.sable.Sable;
+import dev.ryanhcode.sable.api.sublevel.SubLevelContainer;
+import dev.ryanhcode.sable.sublevel.SubLevel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+public final class SableMenuCompat {
+    private SableMenuCompat() {
+    }
+
+    @Nullable
+    public static UUID subLevelUuid(BlockEntity blockEntity) {
+        SubLevel subLevel = Sable.HELPER.getContaining(blockEntity);
+        return subLevel == null ? null : subLevel.getUniqueId();
+    }
+
+    @Nullable
+    public static BlockEntity resolve(Level parentLevel, UUID subLevelUuid, BlockPos pos) {
+        SubLevelContainer container = SubLevelContainer.getContainer(parentLevel);
+        if (container == null) {
+            return null;
+        }
+        SubLevel subLevel = container.getSubLevel(subLevelUuid);
+        if (subLevel == null) {
+            return null;
+        }
+        return subLevel.getLevel().getBlockEntity(pos);
+    }
+}

--- a/src/main/java/dev/ftb/mods/ftbstuffnthings/util/SubLevelMenuHelper.java
+++ b/src/main/java/dev/ftb/mods/ftbstuffnthings/util/SubLevelMenuHelper.java
@@ -1,0 +1,40 @@
+package dev.ftb.mods.ftbstuffnthings.util;
+
+import dev.ftb.mods.ftbstuffnthings.integration.sable.SableMenuCompat;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.neoforged.fml.ModList;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+public final class SubLevelMenuHelper {
+    private static final boolean SABLE_LOADED = ModList.get().isLoaded("sable");
+
+    private SubLevelMenuHelper() {
+    }
+
+    public static void writeLocator(FriendlyByteBuf buf, BlockEntity blockEntity) {
+        buf.writeBlockPos(blockEntity.getBlockPos());
+        UUID subLevelUuid = SABLE_LOADED ? SableMenuCompat.subLevelUuid(blockEntity) : null;
+        buf.writeBoolean(subLevelUuid != null);
+        if (subLevelUuid != null) {
+            buf.writeUUID(subLevelUuid);
+        }
+    }
+
+    @Nullable
+    public static BlockEntity readAndResolve(Player player, FriendlyByteBuf buf) {
+        BlockPos pos = buf.readBlockPos();
+        UUID subLevelUuid = buf.readBoolean() ? buf.readUUID() : null;
+        if (subLevelUuid != null && SABLE_LOADED) {
+            BlockEntity onSubLevel = SableMenuCompat.resolve(player.level(), subLevelUuid, pos);
+            if (onSubLevel != null) {
+                return onSubLevel;
+            }
+        }
+        return player.level().getBlockEntity(pos);
+    }
+}

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -83,5 +83,12 @@ description='''${mod_description}'''
     ordering="NONE"
     side="BOTH"
 
+[[dependencies.${mod_id}]]
+    modId="sable"
+    type="optional"
+    versionRange="[2.0,)"
+    ordering="AFTER"
+    side="BOTH"
+
 [[mixins]]
 config="${mod_id}.mixins.json"


### PR DESCRIPTION
Machine GUIs (Water Strainer, Fusing Machine, Super Cooler, Tempered Jar) were previously inaccessible when placed on Create: Aeronautics / Sable airship sub-levels.

This change introduces an optional soft dependency on Sable. Block entity resolution for opening GUIs

It now checks for a sub-level context, allowing
the UI to correctly open for machines placed on airships.